### PR TITLE
Fixed error on last get raffle request

### DIFF
--- a/src/rafflebot.py
+++ b/src/rafflebot.py
@@ -84,9 +84,11 @@ class RaffleBot:
 
         data = {"start": "", "sort": "0", "puzzle": "0", "csrf": self.csrf}
         url = "https://scrap.tf:443/ajax/raffles/Paginate"
-        lid=[];
+        lid=[]
         while True:
             response = self.session.post(url, data=data).json()
+            if response['done']:
+                break
             print(response['lastid'])
             if response['lastid'] in lid:
                 break


### PR DESCRIPTION
the program was properly pulling the raffles until it got to the last one and it was querying for a 'lastid' list element when there was none. this solves that problem. also removed unnecessary semicolon.